### PR TITLE
Exporting only the main (only) function; 'Comic Neue' font support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Never `curl | bash`. Or you deserve it.
 ## Usage (ES6+)
 
 ```js
-// load dependency.
-import { scrubFontName } from 'font-scrubber';
+// Load dependency.
+import scrubFontName from 'font-scrubber';
 
 // Make sure this font is acceptable.
-let goodFont = scrubFontName("'Comic Sans MS'")
+let goodFont = scrubFontName("'Comic Sans MS'");
 ```
 
 ## Warning!

--- a/index.js
+++ b/index.js
@@ -8,12 +8,10 @@
  * @return {String} acceptable font name
  */
 function scrubFontName(fontname) {
-    if (['"Comic Sans MS"', 'Impact', 'Papyrus'].includes(fontname)) {
+    if (['"Comic Sans MS"', '"Comic Neue"', 'Impact', 'Papyrus'].includes(fontname)) {
         return fontname;
     }
     return '"Comic Sans MS"';
 }
 
-module.exports = {
-    scrubFontName
-};
+module.exports = scrubFontName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "font-scrubber",
-  "version": "1.1.4",
+  "version": "1.2.0",
   "description": "Verifies if your font is acceptable and secure for web use.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
UglifyJs failed trying to minify modules with this one as dependency. So I exported only the main (and the only function) and it helped to fix the build. This made me change also the usage description in README file.

Also I included "Comic Neue" font to the list of allowed fonts as I use it in my test cases. 😄 